### PR TITLE
Improve reliability

### DIFF
--- a/docs/src/markdown/about/changelog.md
+++ b/docs/src/markdown/about/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.3.0
+
+- **NEW**: API for USB library now returns whether it passed or failed. This can indicate a disconnected device.
+- **FIX**: A command may fail for various reasons, so don't remove a command from schedule just because it fails.
+- **FIX**: Add logic to reconnect to a device if it appears the device was disconnected.
+
 ## 1.2.0
 
 - **NEW**: `--wait` removed from CLI as the server should not get hung while waiting. `wait` is still available when

--- a/pyluxa4/__meta__.py
+++ b/pyluxa4/__meta__.py
@@ -185,5 +185,5 @@ def parse_version(ver, pre=False):
     return Version(major, minor, micro, release, pre, post, dev)
 
 
-__version_info__ = Version(1, 2, 0, "final")
+__version_info__ = Version(1, 3, 0, "final")
 __version__ = __version_info__._get_canonical()

--- a/pyluxa4/scheduler.py
+++ b/pyluxa4/scheduler.py
@@ -33,9 +33,10 @@ DAY_MAP = {
 class Scheduler:
     """Scheduler."""
 
-    def __init__(self, handle):
+    def __init__(self, handle, logger):
         """Initialize."""
 
+        self.logger = logger
         self.handle = handle
         self.day_end = self.resolve_times('23:59')[0]
         self.mode_map = {
@@ -179,7 +180,9 @@ class Scheduler:
                 config = json.loads(f.read())
             assert isinstance(config, list)
         except Exception:
-            return "Could not open file or file content was invalid {}".format(schedule)
+            err = "Could not open file or file content was invalid {}".format(schedule)
+            self.logger(err)
+            return err
 
         err = ''
 
@@ -237,6 +240,7 @@ class Scheduler:
                     raise ValueError("Unrecognized command {}".format(cmd_type))
 
             except Exception as e:
+                self.logger.error(e)
                 err = str(e)
                 break
 
@@ -307,7 +311,5 @@ class Scheduler:
             cmd = self.cmds[index]
             try:
                 cmd['cmd'](*cmd['args'], **cmd['kwargs'])
-            except Exception:
-                # Remove bad commands
-                del self.events[index]
-                del self.cmds[index]
+            except Exception as e:
+                self.logger.error(e)


### PR DESCRIPTION
- API for USB library now returns whether it passed or failed. This can
  indicate a disconnected device.
- A command may fail for various reasons, so don't remove a command from
  schedule just because it fails.
- Add logic to reconnect to a device if it appears the device was
  disconnected.